### PR TITLE
New pref: Destination dir to be used for all exported STL files

### DIFF
--- a/Resources/ui/slcr-prefs.ui
+++ b/Resources/ui/slcr-prefs.ui
@@ -16,6 +16,21 @@
   <property name="title" stdset="0">
    <string>Hello World</string>
   </property>
+  
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>431</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Path to slic3r executable:</string>
+   </property>
+  </widget>
+  
   <widget class="Gui::PrefFileChooser" name="fileChooser" native="true">
    <property name="geometry">
     <rect>
@@ -44,19 +59,7 @@
     <cstring>Mod/slcr</cstring>
    </property>
   </widget>
-  <widget class="QLabel" name="label">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>431</width>
-     <height>17</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Path to slic3r executable:</string>
-   </property>
-  </widget>
+  
   <widget class="QLabel" name="label_2">
    <property name="geometry">
     <rect>
@@ -70,6 +73,7 @@
     <string>Path to slic3r profile .ini file:</string>
    </property>
   </widget>
+  
   <widget class="Gui::PrefFileChooser" name="fileChooser_2" native="true">
    <property name="geometry">
     <rect>
@@ -98,7 +102,56 @@
     <cstring>Mod/slcr</cstring>
    </property>
   </widget>
+ 
+  <widget class="QLabel" name="label_3">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>170</y>
+     <width>550</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Destination directory for .stl (empty =&gt; same as document):</string>
+   </property>
+  </widget>
+  
+  <widget class="Gui::PrefFileChooser" name="fileChooser_3" native="true">
+   <property name="mode" >
+    <enum>Gui::FileChooser::Directory</enum>
+   </property>
+
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>200</y>
+     <width>500</width>
+     <height>30</height>
+    </rect>
+   </property>
+   <property name="minimumSize">
+    <size>
+     <width>350</width>
+     <height>0</height>
+    </size>
+   </property>
+   <property name="maximumSize">
+    <size>
+     <width>1000</width>
+     <height>16777215</height>
+    </size>
+   </property>
+   <property name="prefEntry" stdset="0">
+    <cstring>stlExportPath</cstring>
+   </property>
+   <property name="prefPath" stdset="0">
+    <cstring>Mod/slcr</cstring>
+   </property>
+  </widget>
+
  </widget>
+ 
  <layoutdefault spacing="6" margin="11"/>
  <pixmapfunction>qPixmapFromMimeSource</pixmapfunction>
  <customwidgets>

--- a/SlcrDoc.py
+++ b/SlcrDoc.py
@@ -43,7 +43,15 @@ class SlcrDoc:
         if self.doc.FileName=="":
             raise Exception("Please save the document first to give it a filename.")
 
-        return os.path.splitext(self.doc.FileName)[0]+".stl"
+        dir, name = os.path.split(self.doc.FileName)
+        name = os.path.splitext(name)[0]+".stl"
+        
+        preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/slcr")
+        stlPath = preferences.GetString('stlExportPath').strip()
+        if stlPath:
+            dir = stlPath
+        
+        return os.path.join(dir, name)
 
     def getGcodeFileName(self):
         if self.doc.FileName=="":


### PR DESCRIPTION
E.g. set it to /tmp if you use STL files only as intermediate steps
and don't want to keep them around.